### PR TITLE
Add assertion checks so certain points in code no errors

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# MeowTheCat User Guide
+# Duke User Guide
 
 // Update the title above to match the actual product name
 

--- a/src/main/java/meowthecat/DialogBox.java
+++ b/src/main/java/meowthecat/DialogBox.java
@@ -33,6 +33,11 @@ public class DialogBox extends HBox {
             e.printStackTrace();
             System.out.println("Dialog.fxml");
         }
+        assert text != null : "Dialog text should not be null";
+        assert img != null : "Image for DialogBox must not be null";
+
+        assert dialog != null : "dialog Label should have been injected by FXML";
+        assert displayPicture != null : "displayPicture ImageView should have been injected by FXML";
 
         dialog.setText(text);
         displayPicture.setImage(img);

--- a/src/main/java/meowthecat/Main.java
+++ b/src/main/java/meowthecat/Main.java
@@ -19,6 +19,7 @@ public class Main extends Application {
         try {
             FXMLLoader fxmlLoader = new FXMLLoader(Main.class.getResource("/view/MainWindow.fxml"));
             AnchorPane ap = fxmlLoader.load();
+            assert ap != null : "MainWindow FXML root AnchorPane must not be null";
             Scene scene = new Scene(ap);
             stage.setScene(scene);
             fxmlLoader.<MainWindow>getController().setMeow(meow);

--- a/src/main/java/meowthecat/MainWindow.java
+++ b/src/main/java/meowthecat/MainWindow.java
@@ -27,14 +27,16 @@ public class MainWindow extends AnchorPane {
     @FXML
     public void initialize() {
         scrollPane.vvalueProperty().bind(dialogContainer.heightProperty());
-        System.out.println("Classpath root -> " + getClass().getResource("/"));
-        System.out.println("Check cat.png -> " + getClass().getResource("/cat.PNG"));
-        System.out.println("Check cat.png -> " + getClass().getResource("/cat1.PNG"));
-        System.out.println("Check /view/DialogBox.fxml -> " + getClass().getResource("/view/DialogBox.fxml"));
-        System.out.println("Check /view/MainWindow.fxml -> " + getClass().getResource("/view/MainWindow.fxml"));
+
+        // ensure FXML Injected properly
+        assert scrollPane != null : "scrollPane should be injected";
+        assert dialogContainer != null : "dialogContainer should be injected";
 
         userImage = new Image(this.getClass().getResourceAsStream("/cat1.PNG"));
         meowImage = new Image(this.getClass().getResourceAsStream("/cat.PNG"));
+
+        assert userImage != null : "userImage should be present";
+        assert meowImage != null : "MeowTheCat's image should be present";
     }
 
     /** Injects the Duke instance */

--- a/src/main/java/meowthecat/MeowCat.java
+++ b/src/main/java/meowthecat/MeowCat.java
@@ -17,6 +17,8 @@ public class MeowCat {
 
     public MeowCat() {
         this.store = new FileStore(Paths.get("SaveFile.txt"));
+        // store should be there
+        assert this.store != null : "FileStore should not be null after construction";
         TaskCollection loadedTasks;
         try {
             List<Task> loaded = store.load();
@@ -24,6 +26,8 @@ public class MeowCat {
         } catch (IOException | MeowException e) {
             // on failure, start empty (GUI should still work)
             loadedTasks = new TaskCollection();
+            // sanity: tasks collection must be non-null
+            assert loadedTasks != null : "loadedTasks must not be null";
         }
         this.tasks = loadedTasks;
     }
@@ -36,6 +40,8 @@ public class MeowCat {
      * @return response string to display in GUI
      */
     public String getResponse(String input) {
+        // tasks should be non-null
+        assert tasks != null : "tasks must not be null when handling input";
         try {
             if (input == null) {
                 return "MEOW OOPS!!! No input provided.";

--- a/src/main/java/meowthecat/New Text Document.txt
+++ b/src/main/java/meowthecat/New Text Document.txt
@@ -1,0 +1,17 @@
+package meowthecat;
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+
+public class Main extends Application {
+
+    @Override
+    public void start(Stage stage) {
+        Label helloWorld = new Label("Hello World!"); // Creating a new Label control
+        Scene scene = new Scene(helloWorld); // Setting the scene to be our Label
+
+        stage.setScene(scene); // Setting the stage to show our scene
+        stage.show(); // Render the stage.
+    }
+}


### PR DESCRIPTION
Current situation: Some public methods lack defensive assertions and can be used incorrectly by callers (e.g. null/invalid inputs). This makes the project more brittle and harder to debug.

Why change: Add targeted assertions to catch programmer mistakes early and to provide clearer failures during development and testing.

What is done:
Add assertions in MainWindow, DialogBox and MeowCat where necessary.